### PR TITLE
ALBS-76: Fix logs uploading

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,12 @@ RUN dnf install -y epel-release && \
     dnf clean all
 
 RUN curl https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh -o wait_for_it.sh && chmod +x wait_for_it.sh
+# A lot of rpm packages contains unit-tests which should be run as non-root user
+RUN useradd -ms /bin/bash alt
+RUN usermod -aG wheel alt
+RUN usermod -aG mock alt
+RUN echo 'alt ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+RUN echo 'wheel ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
 RUN mkdir -p \
     /srv/alternatives/castor/build_node \
@@ -40,12 +46,6 @@ RUN /build-node/env/bin/pip install --upgrade pip==21.1 && /build-node/env/bin/p
 COPY ./build_node /build-node/build_node
 COPY almalinux_build_node.py /build-node/almalinux_build_node.py
 
-# A lot of rpm packages contains unit-tests which should be run as non-root user
-RUN useradd -ms /bin/bash alt
-RUN usermod -aG wheel alt
-RUN usermod -aG mock alt
-RUN echo 'alt ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
-RUN echo 'wheel ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 RUN chown -R alt:alt /build-node /wait_for_it.sh /srv
 USER alt
 

--- a/build_node/builders/__init__.py
+++ b/build_node/builders/__init__.py
@@ -18,7 +18,7 @@ def get_suitable_builder(task):
 
     Parameters
     ----------
-    task : dict
+    task : Task
         Build task.
 
     Returns

--- a/build_node/uploaders/pulp.py
+++ b/build_node/uploaders/pulp.py
@@ -196,8 +196,9 @@ class PulpBaseUploader(BaseUploader):
             try:
                 artifacts.append(self.upload_single_file(artifact))
             except Exception as e:
-                self._logger.error(f'Cannot upload {artifact}, error: {e}',
-                                   exc_info=e)
+                self._logger.exception(
+                    'Cannot upload %s, error: %s', str(artifact), str(e),
+                    exc_info=e)
                 errored_uploads.append(artifact)
         # TODO: Decide what to do with successfully uploaded artifacts
         #  in case of errors during upload.


### PR DESCRIPTION
We try to upload all artifacts when build is failed. That's mostly not
needed and may cause additional failures (e.g. error with large files
processing that prevented big RPMs being correctly uploaded to Pulp).
In such case we will not receive even logs. This commit should prevent
such situation from happening.