### PR TITLE
Remove unnecessary steps from __spec_install_post for modules signing

### DIFF
--- a/build_node/builders/base_rpm_builder.py
+++ b/build_node/builders/base_rpm_builder.py
@@ -48,11 +48,9 @@ MODSIGN_CONTENT = r"""
 %__brp_kmod_sign %{expand:[ ! -d "$RPM_BUILD_ROOT/lib/modules/"  ] || find "$RPM_BUILD_ROOT/lib/modules/" -type f -name '*.ko' -print -exec /usr/local/bin/modsign %{modsign_os} {} \\\;}
 %__brp_kmod_post_sign_process %{expand:[ ! -d "$RPM_BUILD_ROOT/lib/modules/" ] || find "$RPM_BUILD_ROOT/lib/modules/" -type f -name '*.ko.*' -print -exec rm -f {} \\\;}
 %__spec_install_post \\
-        %{?__brp_kmod_set_exec_bit} \\
         %{?__debug_package:%{__debug_install_post}} \\
         %{__arch_install_post} \\
         %{__os_install_post} \\
-        %{?__brp_kmod_restore_perms} \\
         %{__brp_kmod_sign} \\
         %{__brp_kmod_post_sign_process} \\
         %{nil}


### PR DESCRIPTION
These steps break AlmaLinux 9 builds without kernel-rpm-macros package.