### PR TITLE
Use original URL to determine source file name

### DIFF
--- a/build_node/utils/file_utils.py
+++ b/build_node/utils/file_utils.py
@@ -337,7 +337,14 @@ def download_file(url, dst, ssl_cert=None, ssl_key=None, ca_info=None,
         if not hasattr(dst, 'write'):
             dst_fd.close()
 
-    file_name = os.path.basename(urllib.parse.urlsplit(real_url)[2]).strip()
+    # using the original URL since that should come from the spec file itself
+    # and is actually known there. Problem arises when a site redirects around
+    # the url and the real_url ends up as ending in /v0.3.7 instead of
+    # project-0.3.7.tar.gz (or similar).
+    # Ultimately both cases here are wrong and this is inherently hard if you
+    # have to assume the url doesn't end in the filename you are expecting to
+    # download
+    file_name = os.path.basename(urllib.parse.urlsplit(url)[2]).strip()
     if isinstance(dst, str):
         if tmp_path:
             # rename the temporary file to a real file name if destination


### PR DESCRIPTION
Certain forges allow you to snag a tarball from them using a known URL. In particular one of them will cause a redirect to an ultimate URL that does not end in the expected filename that is present in the SourceN line, which can cause issues of the resulting SRPM from being generated with the actual SourceN file being present, or being an incorrect file (ultimately leading to a failed build).

This switches real_url to url to avoid the situation where the URL for SourceN that's being downloaded doesn't match the resulting real_url.

The other possible source of "truth" here would be to parse the headers from the download itself, and use the content-disposition header's filename value.  This could ALSO be wrong depending on if it's set correctly or not.

Erring on the simpler, and more controllable to the .spec file writer of using the base url.

An option to clarify this behavior may be worth investigating to add some sort of explicit ultimate filename like SourceFilenameN to allow for an explicit rename in this instance.