### PR TITLE
Add ability to set extra git options in config file

### DIFF
--- a/build_node/build_node_config.py
+++ b/build_node/build_node_config.py
@@ -63,6 +63,8 @@ class BuildNodeConfig(BaseConfig):
         Git repositories cache locks directory.
     git_repos_cache_dir : str
         Git repositories cache directory.
+    git_extra_options : list of str
+        Git options to be passed to underlying git commands
     sentry_dsn : str
         Client key to send build data to Sentry.
     pulp_host : str
@@ -99,6 +101,7 @@ class BuildNodeConfig(BaseConfig):
             #       compatibility
             'git_cache_locks_dir': '/srv/alternatives/git_repos_cache/locks/',
             'git_repos_cache_dir': '/srv/alternatives/git_repos_cache/',
+            'git_extra_options': None,
             'native_support': DEFAULT_NATIVE_BUILDING,
             'arm64_support': DEFAULT_ARM64_BUILDING,
             'arm32_support': DEFAULT_ARM32_BUILDING,
@@ -132,6 +135,7 @@ class BuildNodeConfig(BaseConfig):
             'working_dir': {'type': 'string', 'required': True},
             'git_cache_locks_dir': {'type': 'string', 'required': True},
             'git_repos_cache_dir': {'type': 'string', 'required': True},
+            'git_extra_options': {'type': 'list', 'required': False, 'nullable': True},
             'native_support': {'type': 'boolean', 'default': True},
             'arm64_support': {'type': 'boolean', 'default': False},
             'arm32_support': {'type': 'boolean', 'default': False},

--- a/build_node/builders/base_builder.py
+++ b/build_node/builders/base_builder.py
@@ -112,7 +112,7 @@ class BaseBuilder(object):
         with MirroredGitRepo(
                 ref.url, self.config.git_repos_cache_dir,
                 self.config.git_cache_locks_dir,
-                timeout=600) as cached_repo:
+                timeout=600, git_command_extras=self.config.git_extra_options) as cached_repo:
             repo = cached_repo.clone_to(git_sources_dir)
             repo.checkout(ref.git_ref)
         self.__log_commit_id(git_sources_dir)

--- a/build_node/utils/git_utils.py
+++ b/build_node/utils/git_utils.py
@@ -739,7 +739,7 @@ class GitCacheError(Exception):
 class MirroredGitRepo(object):
 
     def __init__(self, repo_url, repos_dir, locks_dir, timeout=60,
-                 logger=None):
+                 git_command_extras=None, logger=None):
         """
         @type repo_url:   str or unicode
         @param repo_url:  Git repository URL.
@@ -750,6 +750,8 @@ class MirroredGitRepo(object):
             need the timeout.
         @type logger:     logging.Logger
         @param logger:    Logger instance to use (optional).
+        @type git_command_extras:  list of str
+        @param git_command_extras: List of extra command line options to be passed to git (optional)
         """
         if not isinstance(repo_url, str):
             raise ValueError("repo_url must be instance of str or unicode")
@@ -781,6 +783,8 @@ class MirroredGitRepo(object):
         self.__lock_file = os.path.join(locks_dir,
                                         "{0}.lock".format(self.__repo_hash))
         self.__fd = None
+
+        self.__git_command_extras = git_command_extras
 
     def clone_to(self, target_dir, branch=None):
         """
@@ -839,7 +843,7 @@ class MirroredGitRepo(object):
                 raise e
         return self
 
-    def __clone_repo(self, repo_url, target_dir, mirror=False, branch=None):
+    def __clone_repo(self, repo_url, target_dir, mirror=False, branch=None, git_opts=None):
         """
         Clones git repository to the specified directory.
 
@@ -849,10 +853,16 @@ class MirroredGitRepo(object):
         @param target_dir:    The name of a new directory to clone into.
         @type mirror:         bool
         @param mirror:        Set up a mirror of the source repository if True.
+        @type git_opts:       list of str
+        @param git_opts:      list of explicit options to append to git command (optional)
 
         @raise GitCacheError: If git-clone execution failed.
         """
         cmd = ["git", "clone"]
+        if self.__git_command_extras is not None:
+            cmd.extend( self.__git_command_extras )
+        if git_opts is not None:
+            cmd.extend( git_opts )
         if mirror:
             cmd.append("--mirror")
         cmd.extend((repo_url, target_dir))


### PR DESCRIPTION
This adds the ability to define git_extra_options which are git options to be passed through to the actual git command, with the specific intention of allowing http ssl verification disabling but there's no reason not to allow other options should they be warranted