### PR TITLE
AlmaLinux/build-system#57: Mount the sources to a container (albs-web-server, albs-sign-node, etc) instead store them into a container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,10 +43,7 @@ WORKDIR /build-node
 COPY requirements.txt /build-node/requirements.txt
 
 RUN python3 -m venv --system-site-packages env
-RUN /build-node/env/bin/pip install --upgrade pip && /build-node/env/bin/pip install -r requirements.txt && /build-node/env/bin/pip cache purge
-
-COPY ./build_node /build-node/build_node
-COPY almalinux_build_node.py /build-node/almalinux_build_node.py
+RUN cd /build-node && source env/bin/activate && pip3 install --upgrade pip && pip3 install -r requirements.txt --no-cache-dir
 
 RUN chown -R alt:alt /build-node /wait_for_it.sh /srv
 USER alt
@@ -55,4 +52,4 @@ USER alt
 # COPY ./tests /build-node/tests
 # RUN /build-node/env/bin/py.test tests
 
-CMD ["/build-node/env/bin/python", "/build-node/almalinux_build_node.py"]
+CMD ["/bin/bash", "-c", "source env/bin/activate && pip3 install --upgrade pip && pip3 install -r requirements.txt --no-cache-dir && python3 almalinux_build_node.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,13 @@
 version: "3.9"
 services:
   build_node:
-    image: albs-node:latest
+    image: quay.io/almalinuxorg/albs-node:latest
     hostname: "${ALBS_HOSTNAME}"
     privileged: true
-    build:
-      dockerfile: Dockerfile
-      context: .
-    command: "bash -c 'source env/bin/activate && ./almalinux_build_node.py -v'"
+    command: "bash -c 'source env/bin/activate && pip3 install --upgrade pip && pip3 install -r requirements.txt --no-cache-dir && python3 almalinux_build_node.py -v'"
     restart: on-failure
     volumes:
       - "./volumes/node_config:/home/alt/.config"
+      - "./requirements.txt:/build-node/requirements.txt"
+      - "./build_node:/build-node/build_node"
+      - "./almalinux_build_node.py:/build-node/almalinux_build_node.py"


### PR DESCRIPTION
- Mount requirements.txt into a container
- Run update of pip and install from requirements.txt before run an executable item in a container
- Mount the sources into a container