### PR TITLE
AlmaLinux/build-system#87: ALBS can't build multiplatform builds beca…

### DIFF
--- a/build_node/build_node_builder.py
+++ b/build_node/build_node_builder.py
@@ -211,7 +211,7 @@ class BuildNodeBuilder(threading.Thread):
                     # NOTE: sometimes source files have weird permissions
                     #       which makes their deletion merely impossible
                     #       without root permissions
-                    rm_sudo(task_dir)
+                    # rm_sudo(task_dir)
                 self.__builder = None
 
     @measure_stage("cas_notarize_artifacts")
@@ -332,7 +332,10 @@ class BuildNodeBuilder(threading.Thread):
     ):
         full_url = urllib.parse.urljoin(
             self.__config.master_url, f'build_node/{endpoint}')
-        if endpoint == 'build_done':
+        if endpoint in (
+            'build_done',
+            'get_task'
+        ):
             session_method = self.__session.post
         else:
             session_method = self.__session.get

--- a/build_node/build_node_builder.py
+++ b/build_node/build_node_builder.py
@@ -211,7 +211,7 @@ class BuildNodeBuilder(threading.Thread):
                     # NOTE: sometimes source files have weird permissions
                     #       which makes their deletion merely impossible
                     #       without root permissions
-                    # rm_sudo(task_dir)
+                    rm_sudo(task_dir)
                 self.__builder = None
 
     @measure_stage("cas_notarize_artifacts")


### PR DESCRIPTION
…use it puts sRPM to a wrong repo

- HTTP-method for route `get_task` is changed from GET to POST, because it sends a request's body (because https://github.com/swagger-api/swagger-ui/issues/8682 & RFC7231)