### PR TITLE
Fix pull requests commit messages checks

### DIFF
--- a/.github/workflows/commit-message.yml
+++ b/.github/workflows/commit-message.yml
@@ -12,7 +12,7 @@ jobs:
     name: Check Commit Message
     runs-on: ubuntu-latest
     steps:
-      - name: Check Line Length
+      - name: Check commit lines length
         uses: gsactions/commit-message-checker@v2
         with:
           pattern: '^.{4,72}'
@@ -20,10 +20,10 @@ jobs:
           error: 'The maximum line length of 72 characters is exceeded.'
           excludeDescription: 'true'
           excludeTitle: 'true'
-      - name: Check for Resolves / Fixes
+          checkAllCommitMessages: 'true'
+          accessToken: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check for Resolves/Fixes links in PR description
         uses: gsactions/commit-message-checker@v2
         with:
-          pattern: '(Resolves|Fixes) AlmaLinux\/build-system\#[0-9]+$'
+          pattern: '(Resolves|Fixes):? (?:https:\/\/github.com\/)?AlmaLinux\/build-system(\/issues\/|#)[0-9]+$'
           error: 'You need at least one "Resolves|Fixes: <issue link>" line.'
-          excludeTitle: 'true'
-          excludeDescription: 'true'


### PR DESCRIPTION
By default, all commit messages in PRs will be checked to ensure that the lines length don't exceed 72 characters.

Also, ensure that the title or description of the PR includes a link to the issue that has been fixed/resolved. Allowed patterns are:

* Fixes AlmaLinux/build-system#1234
* Resolves: https://github.com/AlmaLinux/build-system/issues/1234

Note that it checks the PR title/description, which by default is taken from the first commit added into the PR. This way we ensure that:

* In case of a single commit PR, the commit message includes a resolves/fixes reference.
* In case of multiple commits PR, the first message might not include such reference, and it must be added manually when merging the PR into the main branch. Note that, the title or description of the PR must include such reference, which can be updated manually anytime.

Fixes: https://github.com/AlmaLinux/build-system/issues/146