### PR TITLE
Add ability to download CentOS-like sources

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ RUN <<EOT
   dnf install -y \
     gcc gcc-c++ make cmake git mock keyrings-filesystem sudo \
     libicu libicu-devel kernel-rpm-macros createrepo_c cpio \
-    python3-devel python3-lxml python3-createrepo_c python3-libmodulemd
+    python3-devel python3-lxml python3-createrepo_c python3-libmodulemd \
+    centpkg
   dnf clean all
 EOT
 

--- a/build_node/utils/git_sources_utils.py
+++ b/build_node/utils/git_sources_utils.py
@@ -2,6 +2,8 @@ import os
 import re
 import urllib.parse
 
+from plumbum import local
+
 from build_node.utils.file_utils import download_file
 
 
@@ -46,3 +48,17 @@ class AlmaSourceDownloader(BaseSourceDownloader):
         # sources.almalinux.org doesn't accept default pycurl user-agent
         headers = ['User-Agent: Almalinux build node']
         return download_file(full_url, download_path, http_header=headers)
+
+
+class CentpkgDowloader(BaseSourceDownloader):
+
+    def download_source(self, checksum: str, dst_path: str) -> str:
+        pass
+
+    def download_all(self):
+        if not self.find_metadata_file():
+            return
+        sources_file = os.path.join(self._sources_dir, 'sources')
+        if not os.path.isfile(sources_file):
+            return
+        local['centpkg']['sources']()


### PR DESCRIPTION
This commit adds the ability to download sources via 'centpkg' command when a certain file exists in the git.

Resolves: https://github.com/AlmaLinux/build-system/issues/324