### PR TITLE
Fix exclude build analyzer to account for x86_64_v2 arch

### DIFF
--- a/build_node/builders/base_rpm_builder.py
+++ b/build_node/builders/base_rpm_builder.py
@@ -728,6 +728,8 @@ class BaseRPMBuilder(BaseBuilder):
                 format(arch)
         elif exclusive_arch:
             bit32_arches = {'i386', 'i486', 'i586', 'i686'}
+            if arch == 'x86_64_v2' and 'x86_64' in exclusive_arch:
+                exclusive_arch.append(arch)
             if (arch not in bit32_arches and arch not in exclusive_arch) or \
                     (arch in bit32_arches and
                      not bit32_arches & set(exclusive_arch)):


### PR DESCRIPTION
Resolves: https://github.com/AlmaLinux/build-system/issues/324