### PR TITLE
Exclude projects from node

### DIFF
--- a/build_node/build_node_builder.py
+++ b/build_node/build_node_builder.py
@@ -41,12 +41,7 @@ class BuildNodeBuilder(threading.Thread):
     """Build thread."""
 
     def __init__(
-        self,
-        config,
-        thread_num,
-        terminated_event,
-        graceful_terminated_event,
-        task_queue,
+        self, config, thread_num, terminated_event, graceful_terminated_event
     ):
         """
         Build thread initialization.
@@ -62,9 +57,7 @@ class BuildNodeBuilder(threading.Thread):
         graceful_terminated_event : threading.Event
             Shows, if process got "kill -10" signal.
         """
-        super(BuildNodeBuilder, self).__init__(
-            name='Builder-{0}'.format(thread_num)
-        )
+        super(BuildNodeBuilder, self).__init__(name=f'Builder-{thread_num}')
         self.__config = config
         self.__working_dir = os.path.join(
             config.working_dir, 'builder-{0}'.format(thread_num)
@@ -151,12 +144,8 @@ class BuildNodeBuilder(threading.Thread):
                 )
                 capture_exception(e)
             finally:
-                only_logs = not (
-                    bool(
-                        filter_files(
-                            artifacts_dir, lambda f: f.endswith('.rpm')
-                        )
-                    )
+                only_logs = not bool(
+                    filter_files(artifacts_dir, lambda f: f.endswith('.rpm'))
                 )
                 if success is False:
                     only_logs = True

--- a/build_node/build_node_config.py
+++ b/build_node/build_node_config.py
@@ -32,6 +32,9 @@ DEFAULT_MOCK_BASEDIR = None
 DEFAULT_REQUEST_TIMEOUT = 60  # 1 minute
 DEFAULT_PULP_TIMEOUT = 120  # 2 minutes
 DEFAULT_JWT_TOKEN = 'test_jwt'
+DEFAULT_CACHE_UPDATE_INTERVAL = 600
+DEFAULT_EXCLUSIONS_URL = 'https://git.almalinux.org/almalinux/build-node-exclusions/raw/branch/main'
+DEFAULT_CACHE_SIZE = 1
 
 __all__ = ['BuildNodeConfig']
 
@@ -125,6 +128,10 @@ class BuildNodeConfig(BaseConfig):
             'immudb_public_key_file': None,
             'request_timeout': DEFAULT_REQUEST_TIMEOUT,
             'jwt_token': DEFAULT_JWT_TOKEN,
+            'cache_update_interval': DEFAULT_CACHE_UPDATE_INTERVAL,
+            'exclusions_url': DEFAULT_EXCLUSIONS_URL,
+            'build_node_name': self.get_node_name(),
+            'cache_size': DEFAULT_CACHE_SIZE,
         }
         schema = {
             'development_mode': {'type': 'boolean', 'default': False},
@@ -162,6 +169,10 @@ class BuildNodeConfig(BaseConfig):
             'pulp_timeout': {'type': 'integer', 'min': DEFAULT_PULP_TIMEOUT,
                              'required': True},
             'request_timeout': {'type': 'integer', 'required': True},
+            'cache_update_interval': {'type': 'integer', 'required': True},
+            'exclusions_url': {'type': 'string', 'required': True},
+            'build_node_name': {'type': 'string', 'required': True},
+            'cache_size': {'type': 'integer', 'required': True}
         }
         super(BuildNodeConfig, self).__init__(default_config, config_file,
                                               schema, **cmd_args)

--- a/build_node/build_node_config.py
+++ b/build_node/build_node_config.py
@@ -33,14 +33,15 @@ DEFAULT_REQUEST_TIMEOUT = 60  # 1 minute
 DEFAULT_PULP_TIMEOUT = 120  # 2 minutes
 DEFAULT_JWT_TOKEN = 'test_jwt'
 DEFAULT_CACHE_UPDATE_INTERVAL = 600
-DEFAULT_EXCLUSIONS_URL = 'https://git.almalinux.org/almalinux/build-node-exclusions/raw/branch/main'
+DEFAULT_EXCLUSIONS_URL = (
+    'https://git.almalinux.org/almalinux/build-node-exclusions/raw/branch/main'
+)
 DEFAULT_CACHE_SIZE = 1
 
 __all__ = ['BuildNodeConfig']
 
 
 class BuildNodeConfig(BaseConfig):
-
     """
     Build node configuration storage.
 
@@ -143,7 +144,11 @@ class BuildNodeConfig(BaseConfig):
             'working_dir': {'type': 'string', 'required': True},
             'git_cache_locks_dir': {'type': 'string', 'required': True},
             'git_repos_cache_dir': {'type': 'string', 'required': True},
-            'git_extra_options': {'type': 'list', 'required': False, 'nullable': True},
+            'git_extra_options': {
+                'type': 'list',
+                'required': False,
+                'nullable': True,
+            },
             'native_support': {'type': 'boolean', 'default': True},
             'arm64_support': {'type': 'boolean', 'default': False},
             'arm32_support': {'type': 'boolean', 'default': False},
@@ -166,16 +171,20 @@ class BuildNodeConfig(BaseConfig):
             'immudb_public_key_file': {'type': 'string', 'nullable': True},
             'base_arch': {'type': 'string', 'nullable': False},
             'build_src': {'type': 'boolean', 'nullable': False},
-            'pulp_timeout': {'type': 'integer', 'min': DEFAULT_PULP_TIMEOUT,
-                             'required': True},
+            'pulp_timeout': {
+                'type': 'integer',
+                'min': DEFAULT_PULP_TIMEOUT,
+                'required': True,
+            },
             'request_timeout': {'type': 'integer', 'required': True},
             'cache_update_interval': {'type': 'integer', 'required': True},
             'exclusions_url': {'type': 'string', 'required': True},
             'build_node_name': {'type': 'string', 'required': True},
-            'cache_size': {'type': 'integer', 'required': True}
+            'cache_size': {'type': 'integer', 'required': True},
         }
-        super(BuildNodeConfig, self).__init__(default_config, config_file,
-                                              schema, **cmd_args)
+        super(BuildNodeConfig, self).__init__(
+            default_config, config_file, schema, **cmd_args
+        )
 
     @property
     def codenotary_enabled(self) -> bool:

--- a/build_node/utils/config.py
+++ b/build_node/utils/config.py
@@ -128,6 +128,11 @@ class BaseConfig(object):
         """
         return '{0}.{1}{2}'.format(platform.node(), os.getpid(), postfix)
 
+    @staticmethod
+    def get_node_name():
+        host_name = platform.node()
+        return host_name.rsplit('.', 2)[0]
+
     def __dir__(self):
         return list(self.__config.keys())
 

--- a/build_node/utils/config.py
+++ b/build_node/utils/config.py
@@ -19,7 +19,6 @@ __all__ = ['locate_config_file', 'BaseConfig']
 
 
 class ConfigValidator(cerberus.Validator):
-
     """
     Custom validator for CloudLinux Build System configuration objects.
     """
@@ -70,8 +69,9 @@ def locate_config_file(component, config_path=None):
     if config_path:
         config_path = normalize_path(config_path)
         if not os.path.exists(config_path):
-            raise ValueError('configuration file {0} is not found'.
-                             format(config_path))
+            raise ValueError(
+                'configuration file {0} is not found'.format(config_path)
+            )
         return config_path
     config_path = normalize_path('~/.config/castor/{0}.yml'.format(component))
     if os.path.exists(config_path):
@@ -79,11 +79,11 @@ def locate_config_file(component, config_path=None):
 
 
 class BaseConfig(object):
-
     """Base configuration object for Build System processes."""
 
-    def __init__(self, default_config, config_path=None, schema=None,
-                 **cmd_args):
+    def __init__(
+        self, default_config, config_path=None, schema=None, **cmd_args
+    ):
         """
         Configuration object initialization.
 
@@ -150,7 +150,9 @@ class BaseConfig(object):
     def __validate_config(self, schema):
         validator = ConfigValidator(schema or {})
         if not validator.validate(self.__config):
-            error_list = ['{0}: {1}'.format(k, ', '.join(v))
-                          for k, v in validator.errors.items()]
+            error_list = [
+                '{0}: {1}'.format(k, ', '.join(v))
+                for k, v in validator.errors.items()
+            ]
             raise ValueError('. '.join(error_list))
         self.__config = validator.document

--- a/build_node/utils/file_utils.py
+++ b/build_node/utils/file_utils.py
@@ -14,6 +14,7 @@ import itertools
 import os
 import shutil
 import base64
+import requests
 import tempfile
 import urllib.request
 import urllib.parse
@@ -509,3 +510,26 @@ def is_gzip_file(file_path):
     """
     with open(file_path, 'rb') as fd:
         return binascii.hexlify(fd.read(2)) == b'1f8b'
+
+def file_url_exists(url):
+    """
+    Check if a file exists at the specified URL using a HEAD request.
+
+    Parameters
+    ----------
+    url : str
+        The URL to check.
+
+    Returns
+    -------
+    bool
+        True if the file exists, False otherwise.
+    """
+    try:
+        response = requests.head(url)
+        if response.status_code == 200:
+            return True
+        else:
+            return False
+    except requests.RequestException as e:
+        return False


### PR DESCRIPTION
- Fetch configs from `almalinux/build-node-exclusions` repo
- Added excluded_packages parameter to `/get_task` endpoint
- Using TTL cache for updating the values from the configs
- Black and isort formatting

Resolves: AlmaLinux/build-system#365