### PR TITLE
Fix modsign macro to fail build on signing errors

### DIFF
--- a/build_node/builders/base_rpm_builder.py
+++ b/build_node/builders/base_rpm_builder.py
@@ -59,7 +59,7 @@ from .. import build_node_globals as node_globals
 # or don't touch this at all
 MODSIGN_CONTENT = r"""
 %__brp_kmod_sign %{expand:[ ! -d "$RPM_BUILD_ROOT/lib/modules/" ] || find "$RPM_BUILD_ROOT/lib/modules/" -type f -name '*.ko' -print0 | xargs -0 -r -I{} /usr/local/bin/modsign %{modsign_os} {} }
-%__brp_kmod_post_sign_process %{expand:[ ! -d "$RPM_BUILD_ROOT/lib/modules/" ] || find "$RPM_BUILD_ROOT/lib/modules/" -type f -name '*.ko.*' -print -exec rm -f {} \\\;}
+%__brp_kmod_post_sign_process %{expand:[ ! -d "$RPM_BUILD_ROOT/lib/modules/" ] || find "$RPM_BUILD_ROOT/lib/modules/" -type f -name '*.ko.*' -delete}
 %__spec_install_post \\
         %{?__debug_package:%{__debug_install_post}} \\
         %{__arch_install_post} \\

--- a/build_node/builders/base_rpm_builder.py
+++ b/build_node/builders/base_rpm_builder.py
@@ -58,7 +58,7 @@ from .. import build_node_globals as node_globals
 # 'r' modifier and the number of slashes is intentional, modify very carefully
 # or don't touch this at all
 MODSIGN_CONTENT = r"""
-%__brp_kmod_sign %{expand:[ ! -d "$RPM_BUILD_ROOT/lib/modules/"  ] || find "$RPM_BUILD_ROOT/lib/modules/" -type f -name '*.ko' -print -exec /usr/local/bin/modsign %{modsign_os} {} \\\;}
+%__brp_kmod_sign %{expand:[ ! -d "$RPM_BUILD_ROOT/lib/modules/" ] || find "$RPM_BUILD_ROOT/lib/modules/" -type f -name '*.ko' -print0 | xargs -0 -r -I{} /usr/local/bin/modsign %{modsign_os} {} }
 %__brp_kmod_post_sign_process %{expand:[ ! -d "$RPM_BUILD_ROOT/lib/modules/" ] || find "$RPM_BUILD_ROOT/lib/modules/" -type f -name '*.ko.*' -print -exec rm -f {} \\\;}
 %__spec_install_post \\
         %{?__debug_package:%{__debug_install_post}} \\


### PR DESCRIPTION
Replace find -exec with xargs in __brp_kmod_sign so that a non-zero exit from modsign (e.g. unknown OS returning HTTP 400) propagates and aborts the RPM build instead of silently packaging unsigned modules.