### PR TITLE
uploaders/pulp: parallel chunks, direct artifacts

### DIFF
--- a/build_node/uploaders/pulp.py
+++ b/build_node/uploaders/pulp.py
@@ -1,7 +1,6 @@
-import csv
 import logging
+import math
 import os
-import shutil
 import tempfile
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -9,7 +8,6 @@ from typing import List, Optional, Tuple
 
 from albs_build_lib.builder.models import Artifact
 from albs_common_lib.utils.file_utils import hash_file
-from fsplit.filesplit import Filesplit
 from pulpcore.client.pulpcore.api.artifacts_api import ArtifactsApi
 from pulpcore.client.pulpcore.api.tasks_api import TasksApi
 from pulpcore.client.pulpcore.api.uploads_api import UploadsApi
@@ -62,7 +60,6 @@ class PulpBaseUploader(BaseUploader):
         self._uploads_client = UploadsApi(api_client=api_client)
         self._tasks_client = TasksApi(api_client=api_client)
         self._artifacts_client = ArtifactsApi(api_client=api_client)
-        self._file_splitter = Filesplit()
         self._chunk_size = chunk_size
         self._max_workers = max_workers
         self._requests_timeout = requests_timeout
@@ -135,17 +132,17 @@ class PulpBaseUploader(BaseUploader):
         )
         return response.pulp_href, file_size
 
-    def _commit_upload(self, file_path: str, reference: str) -> str:
+    def _commit_upload(self, reference: str, file_sha256: str) -> str:
         """
         Commits upload and waits until upload will be transformed to artifact.
         Returns artifact reference upon completion.
 
         Parameters
         ----------
-        file_path : str
-            Path to the file.
         reference : str
             Upload reference in Pulp.
+        file_sha256 : str
+            Pre-computed SHA256 of the file.
 
         Returns
         -------
@@ -153,7 +150,6 @@ class PulpBaseUploader(BaseUploader):
             Reference to the created resource.
 
         """
-        file_sha256 = hash_file(file_path, hash_type='sha256')
         response = self._uploads_client.commit(
             reference,
             {'sha256': file_sha256},
@@ -168,41 +164,94 @@ class PulpBaseUploader(BaseUploader):
                 return pulp_href
             raise
 
-    def _put_large_file(self, file_path: str, reference: str):
-        temp_dir = tempfile.mkdtemp(prefix='pulp_uploader_')
-        try:
-            lower_bytes_limit = 0
-            total_size = os.path.getsize(file_path)
-            self._file_splitter.split(
-                file_path, self._chunk_size, output_dir=temp_dir
-            )
-            manifest_path = os.path.join(temp_dir, 'fs_manifest.csv')
-            with open(manifest_path, 'r') as f:
-                for meta in csv.DictReader(f):
-                    split_file_path = os.path.join(temp_dir, meta['filename'])
-                    upper_bytes_limit = (
-                        lower_bytes_limit + int(meta['filesize']) - 1
-                    )
-                    self._uploads_client.update(
-                        f'bytes {lower_bytes_limit}-{upper_bytes_limit}/'
-                        f'{total_size}',
-                        reference,
-                        split_file_path,
-                        _request_timeout=self._requests_timeout,
-                    )
-                    lower_bytes_limit += int(meta['filesize'])
-        finally:
-            if temp_dir and os.path.exists(temp_dir):
-                shutil.rmtree(temp_dir)
+    def _create_artifact_direct(
+        self, file_path: str, file_sha256: str
+    ) -> str:
+        response = self._artifacts_client.create(
+            file_path,
+            sha256=file_sha256,
+            _request_timeout=self._requests_timeout,
+        )
+        return response.pulp_href
 
-    def _send_file(self, file_path: str):
-        reference, file_size = self._create_upload(file_path)
-        if file_size > self._chunk_size:
-            self._logger.debug(
-                'File size exceeded %d, sending file in parts',
-                self._chunk_size,
+    def _put_large_file(self, file_path: str, reference: str):
+        total_size = os.path.getsize(file_path)
+
+        # Build list of (offset, length) chunk descriptors
+        chunks = []
+        offset = 0
+        while offset < total_size:
+            length = min(self._chunk_size, total_size - offset)
+            chunks.append((offset, length))
+            offset += length
+
+        def _upload_chunk(chunk_offset: int, chunk_length: int):
+            """Read a byte range from source and upload via a temp file."""
+            tmp_path = None
+            try:
+                with open(file_path, 'rb') as src:
+                    src.seek(chunk_offset)
+                    data = src.read(chunk_length)
+                tmp = tempfile.NamedTemporaryFile(
+                    delete=False, prefix='pulp_chunk_'
+                )
+                tmp_path = tmp.name
+                tmp.write(data)
+                tmp.close()
+                end_byte = chunk_offset + chunk_length - 1
+                content_range = (
+                    f'bytes {chunk_offset}-{end_byte}/{total_size}'
+                )
+                self._uploads_client.update(
+                    content_range,
+                    reference,
+                    tmp_path,
+                    _request_timeout=self._requests_timeout,
+                )
+            finally:
+                if tmp_path and os.path.exists(tmp_path):
+                    os.unlink(tmp_path)
+
+        with ThreadPoolExecutor(
+            max_workers=self._max_workers
+        ) as executor:
+            futures = {
+                executor.submit(_upload_chunk, off, length): (off, length)
+                for off, length in chunks
+            }
+            for future in as_completed(futures):
+                future.result()  # propagates any exception
+
+    def _send_file(self, file_path: str, file_sha256: str):
+        file_size = os.path.getsize(file_path)
+        file_name = os.path.basename(file_path)
+        start_time = time.time()
+        if file_size < self._chunk_size:
+            artifact_href = self._create_artifact_direct(
+                file_path, file_sha256
             )
+            elapsed = time.time() - start_time
+            self._logger.info(
+                'Upload complete: %s (%d bytes) via direct artifact'
+                ' in %.2fs',
+                file_name,
+                file_size,
+                elapsed,
+            )
+            return artifact_href
+        reference, _ = self._create_upload(file_path)
+        if file_size > self._chunk_size:
             self._put_large_file(file_path, reference)
+            num_chunks = math.ceil(file_size / self._chunk_size)
+            artifact_href = self._commit_upload(reference, file_sha256)
+            elapsed = time.time() - start_time
+            self._logger.info(
+                'Upload complete: %s (%d bytes) via %d chunks in %.2fs',
+                file_name,
+                file_size,
+                num_chunks,
+                elapsed,
+            )
         else:
             self._uploads_client.update(
                 f'bytes 0-{file_size - 1}/{file_size}',
@@ -210,7 +259,15 @@ class PulpBaseUploader(BaseUploader):
                 file_path,
                 _request_timeout=self._requests_timeout,
             )
-        artifact_href = self._commit_upload(file_path, reference)
+            artifact_href = self._commit_upload(reference, file_sha256)
+            elapsed = time.time() - start_time
+            self._logger.info(
+                'Upload complete: %s (%d bytes) via single chunk'
+                ' in %.2fs',
+                file_name,
+                file_size,
+                elapsed,
+            )
         return artifact_href
 
     def check_if_artifact_exists(self, sha256: str) -> Optional[str]:
@@ -270,7 +327,7 @@ class PulpBaseUploader(BaseUploader):
         file_sha256 = hash_file(filename, hash_type='sha256')
         reference = self.check_if_artifact_exists(file_sha256)
         if not reference:
-            reference = self._send_file(filename)
+            reference = self._send_file(filename, file_sha256)
         return Artifact(
             name=os.path.basename(filename),
             href=reference,

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ retrying==1.3.4
 pycurl==7.45.3
 pyicu==2.14
 pyyaml==6.0.2
-filesplit==3.0.2
+
 pulpcore-client==3.67.0
 pydantic==2.9.2
 python-rpm-spec==0.15.0

--- a/tests/build_node/uploaders/pulp_test.py
+++ b/tests/build_node/uploaders/pulp_test.py
@@ -1,5 +1,7 @@
+import logging
 import operator
 import os
+import threading
 from unittest.mock import Mock, patch
 
 from albs_build_lib.builder.models import Artifact
@@ -111,5 +113,239 @@ class TestPulpRpmUploader(TestCase):
             patch.object(PulpRpmUploader, 'check_if_artifact_exists', return_value=None)
         ):
             uploader = PulpRpmUploader('localhost', 'user', 'password', f_size, 1)
-            artifact_href = uploader._send_file(f_path)
+            artifact_href = uploader._send_file(f_path, f_hash)
             assert artifact_href == f_href
+
+    def test_send_file_direct_artifact(self):
+        """Small files (< chunk_size) use direct artifact creation."""
+        f_path = '/build_dir/package.rpm'
+        f_hash = hash_file(f_path, hash_type="sha256")
+        f_href = 'direct_artifact_href'
+        chunk_size = 100  # file is smaller than this
+
+        class ArtifactsApi:
+            def __init__(*_, **__):
+                pass
+
+            def create(_, file_path, sha256=None, **__):
+                assert file_path == f_path
+                assert sha256 == f_hash
+                response = Mock()
+                response.pulp_href = f_href
+                return response
+
+            def list(_, sha256, **__):
+                response = Mock()
+                response.results = []
+                return response
+
+        class UploadsApi:
+            def __init__(*_, **__):
+                pass
+
+            def create(*_, **__):
+                raise AssertionError('UploadsApi.create should not be called')
+
+            def update(*_, **__):
+                raise AssertionError('UploadsApi.update should not be called')
+
+            def commit(*_, **__):
+                raise AssertionError('UploadsApi.commit should not be called')
+
+        with (
+            patch('build_node.uploaders.pulp.ArtifactsApi', new=ArtifactsApi),
+            patch('build_node.uploaders.pulp.UploadsApi', new=UploadsApi),
+        ):
+            uploader = PulpRpmUploader(
+                'localhost', 'user', 'password', chunk_size, 1
+            )
+            artifact = uploader.upload_single_file(f_path)
+            assert artifact.href == f_href
+            assert artifact.sha256 == f_hash
+
+    def test_send_large_file(self):
+        """Large files are uploaded via parallel chunk PUTs."""
+        f_path = '/build_dir/largefile.rpm'
+        self.fs.create_file(f_path, contents='A' * 100)
+        f_hash = hash_file(f_path, hash_type="sha256")
+        f_size = 100
+        chunk_size = 30  # 4 chunks: 30+30+30+10
+        upload_href = 'upload_href_large'
+        artifact_href = 'artifact_href_large'
+
+        lock = threading.Lock()
+        update_calls = []
+
+        class UploadsApi:
+            def __init__(*_, **__):
+                pass
+
+            def create(_, opts, **__):
+                assert opts['size'] == f_size
+                response = Mock()
+                response.pulp_href = upload_href
+                return response
+
+            def update(_, content_range, ref, file, **__):
+                assert ref == upload_href
+                with lock:
+                    update_calls.append(content_range)
+
+            def commit(_, ref, commit_data, **__):
+                assert ref == upload_href
+                assert commit_data['sha256'] == f_hash
+                response = Mock()
+                response.task = 'task_large'
+                return response
+
+        class TasksApi:
+            def __init__(*_, **__):
+                pass
+
+            def read(_, task_href, **__):
+                result = Mock()
+                result.state = 'completed'
+                result.created_resources = [artifact_href]
+                return result
+
+        with (
+            patch('build_node.uploaders.pulp.UploadsApi', new=UploadsApi),
+            patch('build_node.uploaders.pulp.TasksApi', new=TasksApi),
+            patch.object(
+                PulpRpmUploader, 'check_if_artifact_exists',
+                return_value=None,
+            ),
+        ):
+            uploader = PulpRpmUploader(
+                'localhost', 'user', 'password', chunk_size, 4
+            )
+            href = uploader._send_file(f_path, f_hash)
+            assert href == artifact_href
+            assert len(update_calls) == 4
+            ranges = sorted(update_calls)
+            assert ranges == [
+                'bytes 0-29/100',
+                'bytes 30-59/100',
+                'bytes 60-89/100',
+                'bytes 90-99/100',
+            ]
+
+    def test_send_large_file_chunk_error(self):
+        """Errors in chunk uploads propagate correctly."""
+        f_path = '/build_dir/errfile.rpm'
+        self.fs.create_file(f_path, contents='B' * 100)
+        f_hash = hash_file(f_path, hash_type="sha256")
+        upload_href = 'upload_href_err'
+
+        class UploadsApi:
+            def __init__(*_, **__):
+                pass
+
+            def create(_, opts, **__):
+                response = Mock()
+                response.pulp_href = upload_href
+                return response
+
+            def update(*_, **__):
+                raise RuntimeError('chunk upload failed')
+
+        with (
+            patch('build_node.uploaders.pulp.UploadsApi', new=UploadsApi),
+            patch.object(
+                PulpRpmUploader, 'check_if_artifact_exists',
+                return_value=None,
+            ),
+        ):
+            uploader = PulpRpmUploader(
+                'localhost', 'user', 'password', 30, 4
+            )
+            try:
+                uploader._send_file(f_path, f_hash)
+                assert False, 'Expected RuntimeError'
+            except RuntimeError as e:
+                assert 'chunk upload failed' in str(e)
+
+    def test_upload_timing_log_direct(self):
+        """Direct artifact upload emits a timing log."""
+        f_path = '/build_dir/package.rpm'
+        f_hash = hash_file(f_path, hash_type="sha256")
+        f_href = 'timing_direct_href'
+
+        class ArtifactsApi:
+            def __init__(*_, **__):
+                pass
+
+            def create(_, file_path, sha256=None, **__):
+                response = Mock()
+                response.pulp_href = f_href
+                return response
+
+            def list(_, sha256, **__):
+                response = Mock()
+                response.results = []
+                return response
+
+        with (
+            patch('build_node.uploaders.pulp.ArtifactsApi', new=ArtifactsApi),
+            patch('build_node.uploaders.pulp.UploadsApi', Mock),
+        ):
+            uploader = PulpRpmUploader(
+                'localhost', 'user', 'password', 100, 1
+            )
+            with self.assertLogs(level=logging.INFO) as cm:
+                uploader._send_file(f_path, f_hash)
+            log_output = '\n'.join(cm.output)
+            assert 'Upload complete' in log_output
+            assert 'direct artifact' in log_output
+
+    def test_upload_timing_log_chunked(self):
+        """Chunked upload emits a timing log."""
+        f_path = '/build_dir/largefile2.rpm'
+        self.fs.create_file(f_path, contents='C' * 50)
+        f_hash = hash_file(f_path, hash_type="sha256")
+        upload_href = 'upload_timing'
+        artifact_href = 'artifact_timing'
+
+        class UploadsApi:
+            def __init__(*_, **__):
+                pass
+
+            def create(_, opts, **__):
+                response = Mock()
+                response.pulp_href = upload_href
+                return response
+
+            def update(*_, **__):
+                pass
+
+            def commit(_, ref, data, **__):
+                response = Mock()
+                response.task = 'task_timing'
+                return response
+
+        class TasksApi:
+            def __init__(*_, **__):
+                pass
+
+            def read(_, task_href, **__):
+                result = Mock()
+                result.state = 'completed'
+                result.created_resources = [artifact_href]
+                return result
+
+        with (
+            patch('build_node.uploaders.pulp.UploadsApi', new=UploadsApi),
+            patch('build_node.uploaders.pulp.TasksApi', new=TasksApi),
+            patch.object(
+                PulpRpmUploader, 'check_if_artifact_exists',
+                return_value=None,
+            ),
+        ):
+            uploader = PulpRpmUploader(
+                'localhost', 'user', 'password', 20, 4
+            )
+            with self.assertLogs(level=logging.INFO) as cm:
+                uploader._send_file(f_path, f_hash)
+            log_output = '\n'.join(cm.output)
+            assert 'Upload complete' in log_output
+            assert 'chunks' in log_output


### PR DESCRIPTION
- Replace sequential filesplit-based disk splitting with parallel ThreadPoolExecutor chunk uploads using byte-range reads via temp files
- Add direct artifact creation via ArtifactsApi.create() for files smaller than chunk_size, bypassing the 3-step upload+commit flow
- Eliminate redundant SHA256 hashing: file is now hashed once in upload_single_file and the hash is passed through _send_file and _commit_upload (was hashed 3 times per upload)
- Add per-file upload timing logs at INFO level for all three upload paths (direct artifact, single chunk, multi-chunk)
- Remove filesplit dependency from requirements.txt
- Add 5 new tests: direct artifact creation, parallel chunk upload, chunk error propagation, and timing log verification for both paths