### PR TITLE
Pin build workers to NUMA nodes for locality

### DIFF
--- a/almalinux_build_node.py
+++ b/almalinux_build_node.py
@@ -177,15 +177,20 @@ def main(sys_args):
     )
 
     for thread_num in range(0, config.threads_count):
+        numa_node_id, numa_cpus = numa_assignments[thread_num]
         builder = BuildNodeBuilder(
             config,
             thread_num,
             node_terminated,
             node_graceful_terminated,
             task_queue,
-            numa_cpus=numa_assignments[thread_num],
+            numa_cpus=numa_cpus,
+            numa_node_id=numa_node_id,
         )
         builders.append(builder)
+    for builder in builders:
+        builder.set_siblings(builders)
+    for builder in builders:
         builder.start()
 
     builder_supervisor = BuilderSupervisor(

--- a/almalinux_build_node.py
+++ b/almalinux_build_node.py
@@ -20,6 +20,7 @@ from build_node.build_node_builder import BuildNodeBuilder
 from build_node.build_node_config import BuildNodeConfig
 from build_node.build_node_supervisor import BuilderSupervisor
 from build_node.utils.config import locate_config_file
+from build_node.utils.numa import build_numa_assignments
 
 running = True
 
@@ -171,6 +172,10 @@ def main(sys_args):
     builders = []
     task_queue = queue.Queue(maxsize=config.queue_size)
 
+    numa_assignments = build_numa_assignments(
+        config.threads_count, config.numa_aware
+    )
+
     for thread_num in range(0, config.threads_count):
         builder = BuildNodeBuilder(
             config,
@@ -178,6 +183,7 @@ def main(sys_args):
             node_terminated,
             node_graceful_terminated,
             task_queue,
+            numa_cpus=numa_assignments[thread_num],
         )
         builders.append(builder)
         builder.start()

--- a/build_node/build_node_builder.py
+++ b/build_node/build_node_builder.py
@@ -44,6 +44,7 @@ class BuildNodeBuilder(BaseSlaveBuilder):
         graceful_terminated_event,
         task_queue: Queue,
         numa_cpus=None,
+        numa_node_id=None,
     ):
         """
         Build thread initialization.
@@ -63,11 +64,16 @@ class BuildNodeBuilder(BaseSlaveBuilder):
         numa_cpus : list of int, optional
             CPU identifiers the thread (and the mock processes it spawns)
             must be pinned to so that a build stays on a single NUMA node.
+        numa_node_id : int, optional
+            NUMA node identifier the thread is pinned to. Used for
+            cross-node load balancing when picking up tasks.
         """
         super().__init__(
             thread_num=thread_num,
             numa_cpus=numa_cpus,
         )
+        self.__numa_node_id = numa_node_id
+        self.__siblings = ()
         self.__config = config
         # current task processing start timestamp
         self.__start_ts = None
@@ -302,6 +308,9 @@ class BuildNodeBuilder(BaseSlaveBuilder):
     def __request_task(self):
         if self.__task_queue.empty():
             return
+        if self.__should_yield_to_other_node():
+            self.__terminated_event.wait(0.5)
+            return
         task = self.__task_queue.get()
         return Task(**task)
 
@@ -433,3 +442,47 @@ class BuildNodeBuilder(BaseSlaveBuilder):
     @property
     def current_task_id(self):
         return self.__current_task_id
+
+    @property
+    def numa_node_id(self):
+        return self.__numa_node_id
+
+    def set_siblings(self, builders):
+        """
+        Provides references to peer builders for NUMA load balancing.
+
+        Must be called after all builders have been constructed and before
+        any of them is started. Stores every other builder so that
+        ``__should_yield_to_other_node`` can compare per-node active build
+        counts when this thread considers picking up a task.
+        """
+        self.__siblings = tuple(b for b in builders if b is not self)
+
+    def __should_yield_to_other_node(self):
+        """
+        Returns True when another NUMA node has strictly fewer active
+        builds than this builder's node.
+
+        Used to back off from grabbing a queued task when a peer on a less
+        loaded node should take it instead, keeping work distributed across
+        NUMA nodes rather than all funnelled to whichever thread happens to
+        win ``Queue.get()``.
+        """
+        if self.__numa_node_id is None or not self.__siblings:
+            return False
+        my_active = sum(
+            1 for b in self.__siblings
+            if b.numa_node_id == self.__numa_node_id
+            and b.current_task_id is not None
+        )
+        other_nodes = {
+            b.numa_node_id for b in self.__siblings
+        } - {self.__numa_node_id}
+        return any(
+            sum(
+                1 for b in self.__siblings
+                if b.numa_node_id == other
+                and b.current_task_id is not None
+            ) < my_active
+            for other in other_nodes
+        )

--- a/build_node/build_node_builder.py
+++ b/build_node/build_node_builder.py
@@ -43,6 +43,7 @@ class BuildNodeBuilder(BaseSlaveBuilder):
         terminated_event,
         graceful_terminated_event,
         task_queue: Queue,
+        numa_cpus=None,
     ):
         """
         Build thread initialization.
@@ -59,9 +60,13 @@ class BuildNodeBuilder(BaseSlaveBuilder):
             Shows, if process got "kill -10" signal.
         task_queue: queue.Queue
             Shared queue with build tasks
+        numa_cpus : list of int, optional
+            CPU identifiers the thread (and the mock processes it spawns)
+            must be pinned to so that a build stays on a single NUMA node.
         """
         super().__init__(
             thread_num=thread_num,
+            numa_cpus=numa_cpus,
         )
         self.__config = config
         # current task processing start timestamp
@@ -93,6 +98,7 @@ class BuildNodeBuilder(BaseSlaveBuilder):
         self.__task_queue = task_queue
 
     def run(self):
+        self.apply_numa_affinity()
         log_file = os.path.join(
             self.__working_dir, 'bt-{0}.log'.format(self.name)
         )

--- a/build_node/build_node_config.py
+++ b/build_node/build_node_config.py
@@ -34,6 +34,7 @@ DEFAULT_EXCLUSIONS_URL = (
     'https://git.almalinux.org/almalinux/build-node-exclusions/raw/branch/main/'
 )
 DEFAULT_CACHE_SIZE = 1
+DEFAULT_NUMA_AWARE = True
 
 __all__ = ['BuildNodeConfig']
 
@@ -134,6 +135,7 @@ class BuildNodeConfig(BaseConfig):
             'exclusions_url': DEFAULT_EXCLUSIONS_URL,
             'build_node_name': self.get_node_name(),
             'cache_size': DEFAULT_CACHE_SIZE,
+            'numa_aware': DEFAULT_NUMA_AWARE,
         }
         schema = {
             'development_mode': {'type': 'boolean', 'default': False},
@@ -183,6 +185,7 @@ class BuildNodeConfig(BaseConfig):
             'exclusions_url': {'type': 'string', 'required': True},
             'build_node_name': {'type': 'string', 'required': True},
             'cache_size': {'type': 'integer', 'required': True},
+            'numa_aware': {'type': 'boolean', 'default': True},
         }
         super(BuildNodeConfig, self).__init__(
             default_config, config_file, schema, **cmd_args

--- a/build_node/utils/numa.py
+++ b/build_node/utils/numa.py
@@ -1,0 +1,49 @@
+"""
+NUMA worker placement policy for the build node.
+"""
+
+
+import logging
+
+from albs_build_lib.builder.numa import numa_nodes
+
+
+def build_numa_assignments(threads_count, numa_aware):
+    """
+    Computes per-thread NUMA CPU assignments for the build node workers.
+
+    Workers are distributed round-robin across the NUMA nodes that have CPUs
+    assigned to them. Each worker is given the full CPU set of its node so
+    that mock and its child processes can use every core on that node while
+    still staying confined to it.
+
+    Parameters
+    ----------
+    threads_count : int
+        Number of build threads the node will spawn.
+    numa_aware : bool
+        Whether NUMA-aware placement is enabled in the configuration.
+
+    Returns
+    -------
+    list of (list of int or None)
+        One entry per build thread. ``None`` means "do not pin"; a list is the
+        CPU set the corresponding thread must be confined to.
+    """
+    if not numa_aware:
+        return [None] * threads_count
+    nodes = numa_nodes()
+    if len(nodes) < 2:
+        return [None] * threads_count
+    node_ids = list(nodes)
+    assignments = []
+    for thread_num in range(threads_count):
+        node_id = node_ids[thread_num % len(node_ids)]
+        assignments.append(list(nodes[node_id]))
+    logging.info(
+        'NUMA-aware placement enabled: %d threads distributed across '
+        'nodes %s',
+        threads_count,
+        node_ids,
+    )
+    return assignments

--- a/build_node/utils/numa.py
+++ b/build_node/utils/numa.py
@@ -26,20 +26,22 @@ def build_numa_assignments(threads_count, numa_aware):
 
     Returns
     -------
-    list of (list of int or None)
-        One entry per build thread. ``None`` means "do not pin"; a list is the
-        CPU set the corresponding thread must be confined to.
+    list of tuple of (int or None, list of int or None)
+        One entry per build thread. ``(None, None)`` means "do not pin";
+        otherwise the tuple is ``(node_id, cpus)`` where ``cpus`` is the CPU
+        set the corresponding thread must be confined to and ``node_id`` is
+        the NUMA node identifier used for cross-node load balancing.
     """
     if not numa_aware:
-        return [None] * threads_count
+        return [(None, None)] * threads_count
     nodes = numa_nodes()
     if len(nodes) < 2:
-        return [None] * threads_count
+        return [(None, None)] * threads_count
     node_ids = list(nodes)
     assignments = []
     for thread_num in range(threads_count):
         node_id = node_ids[thread_num % len(node_ids)]
-        assignments.append(list(nodes[node_id]))
+        assignments.append((node_id, list(nodes[node_id])))
     logging.info(
         'NUMA-aware placement enabled: %d threads distributed across '
         'nodes %s',

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,4 @@ pulpcore-client==3.67.0
 pydantic==2.9.2
 python-rpm-spec==0.15.0
 git+https://github.com/AlmaLinux/immudb-wrapper.git@0.1.8#egg=immudb_wrapper
-git+https://github.com/AlmaLinux/albs-build-lib.git@0.1.8#egg=albs_build_lib
+git+https://github.com/AlmaLinux/albs-build-lib.git@0.1.9#egg=albs_build_lib


### PR DESCRIPTION
## Summary
- Distribute build workers round-robin across NUMA nodes that have CPUs and pin each worker (and the mock processes it spawns) to the CPU set of its assigned node, keeping every build within a single NUMA node.
- New `build_node/utils/numa.py` implements the placement policy on top of `albs_build_lib.builder.numa`. Workers receive the full per-node CPU set so mock can use every core on the node while staying confined to it.
- Balance task pickup across NUMA nodes: each builder, before grabbing a task off the shared queue, checks per-node active build counts and yields when another node has strictly fewer active builds. Stops the race on `Queue.get()` from concentrating consecutive tasks on a single node when others are idle. Handles asymmetric worker counts correctly (e.g. 3 workers across 2 nodes).
- New `numa_aware` config flag (default `True`); placement and load balancing are no-ops when disabled, when `/sys/devices/system/node/` is unavailable, or when the host has fewer than two NUMA nodes.
- Handles non-contiguous NUMA node ids such as `0` and `8` on ppc64le.
- Bumps `albs-build-lib` to 0.1.9 (depends on AlmaLinux/albs-build-lib#6).

## Note on RPM build parallelism
RPM derives `%{?_smp_mflags}` from `getconf _NPROCESSORS_ONLN`, which is not affinity-aware, so a kernel build on a pinned worker would still spawn `make -j<host-cpu-count>`. This is handled out-of-tree by setting `%_smp_build_ncpus %(nproc)` in the platform config — `nproc(1)` respects `sched_getaffinity` and therefore reports only the per-NUMA-node CPU count once the worker is pinned. No build-node code change is required for this part.

## Test plan
- [ ] Verify a single-node host runs unchanged (no affinity applied, no yielding).
- [ ] Verify a multi-node x86_64 host distributes workers round-robin and `taskset -p <builder-pid>` shows the expected node CPU mask.
- [ ] Verify a ppc64le host with nodes `0` and `8` distributes workers across both and mock children inherit the mask.
- [ ] Verify on a 2-NUMA-node aarch64 host (e.g. 160 CPUs / 2 nodes) that with `%_smp_build_ncpus %(nproc)` set in the platform config, the kernel build invokes `make -j80` rather than `make -j160`.
- [ ] Verify with 3 workers across 2 NUMA nodes (one node receives 2 workers, the other 1) that consecutive tasks land on opposite nodes when both have idle capacity, and that all 3 workers end up busy under load.
- [ ] Verify `numa_aware: false` in the config disables pinning and load balancing entirely.
